### PR TITLE
Redux 0.2.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,47 @@
+default_language_version:
+  python: python3.8
+
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.5.0
+    hooks:
+      - id: check-ast
+      - id: check-byte-order-marker
+      - id: check-merge-conflict
+      - id: debug-statements
+      - id: end-of-file-fixer
+      - id: mixed-line-ending
+      - id: trailing-whitespace
+
+  - repo: https://github.com/asottile/pyupgrade
+    rev: v3.15.0
+    hooks:
+      - id: pyupgrade
+        args: ["--py37-plus"]
+
+  - repo: https://github.com/asottile/reorder_python_imports
+    rev: v3.12.0
+    hooks:
+      - id: reorder-python-imports
+        name: Reorder Python imports
+        args: ["--application-directories", "datadoglog"]
+
+  - repo: https://github.com/psf/black
+    rev: 23.9.1
+    hooks:
+      - id: black
+
+  - repo: https://github.com/pycqa/flake8
+    rev: 6.1.0
+    hooks:
+      - id: flake8
+        additional_dependencies:
+          - flake8-bugbear
+          - flake8-implicit-str-concat
+        args: ["--max-line-length", "88"]
+
+  - repo: https://github.com/pycqa/pylint
+    rev: v3.0.1
+    hooks:
+      - id: pylint
+        args: ["--disable", "bad-inline-option,broad-exception-caught,deprecated-pragma,file-ignored,invalid-name,locally-disabled,missing-class-docstring,missing-function-docstring,missing-module-docstring,no-else-raise,raw-checker-failed,suppressed-message,too-few-public-methods,use-symbolic-message-instead,useless-suppression"]

--- a/LICENSE
+++ b/LICENSE
@@ -175,7 +175,7 @@
 
    END OF TERMS AND CONDITIONS
 
-   Copyright 2018 G Adventures
+   Copyright 2023 G Adventures
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -1,28 +1,31 @@
 # datadoglog
-Python logging handlers for sending logs to Data Dog
+
+Python logging handlers for sending logs to Datadog
 
 ## Installation
 
 to `requirements.txt` add
 
-    -e git+https://github.com/gadventures/datadoglog.git@0.1.0#egg=datadoglog
+    -e git+https://github.com/gadventures/datadoglog.git@0.2.0#egg=datadoglog
 
-## Setup
+## Usage
 
-This package uses QueueHandler logger so first thing you need to start the logger thread and give it a Queue
+This package uses the `QueueHandler` logger, so you need to start the logger
+thread and give it a `Queue`.
 
 ```python
 import atexit
 from queue import Queue
-from datadoglog import start_logger
 
-que = Queue()
-stop_func = start_logger(que)
-atexit.register(stop_func)
+from datadoglog import start_datadog_logger
+
+queue = Queue()
+stop_logger = start_datadog_logger(queue)
+atexit.register(stop_logger)
 ```
-    
-Now that the consumer is runnning you can configure your logging
-below is a sample config using python dictConfig
+
+Now that the handler is running you can configure your logging. Below is a
+sample config using python's `dictConfig`.
 
 ```python
 from logging.config import dictConfig
@@ -31,28 +34,29 @@ log_config = {
     "version": 1,
     "formatters": {
         "data_dog": {
-            "()": 'datadoglog.FormatFactory',
-            "app_key": config.DATADOG_APP_KEY,
-            "source": "sieve",
-            "service": "server_log",
-            "env": "production" if config.PROD else "staging",
+            "()": 'datadoglog.DatadogFormatter',
+            "app_key": "<datadog_api_key>",
+            "env": "production",
+            "service": "project-web",
+            "source": "project",
         },
     },
     "handlers": {
-        "my_handler": {
+        "dd_handler": {
             "class": 'logging.handlers.QueueHandler',
-            "queue": que,
-            "level": 'INFO',
             "formatter": 'data_dog',
+            "level": 'INFO',
+            "queue": queue,
         },
     },
     "loggers": {
         "root": {
             "level": "DEBUG",
-            "handlers": ["my_handler"],
+            "handlers": ["dd_handler"],
         },
     },
 }
 
+# set the config
 dictConfig(log_config)
 ```

--- a/datadoglog/__init__.py
+++ b/datadoglog/__init__.py
@@ -1,7 +1,7 @@
-from .formatters import FormatFactory
-from .handlers import start_logger
+from .formatters import DatadogFormatFactory
+from .handlers import start_datadog_logger
 
-__all__ = [
-    'FormatFactory',
-    'start_logger',
-]
+__all__ = (
+    "DatadogFormatFactory",
+    "start_datadog_logger",
+)

--- a/datadoglog/__init__.py
+++ b/datadoglog/__init__.py
@@ -1,7 +1,7 @@
-from .formatters import DatadogFormatFactory
+from .formatters import DatadogFormatter
 from .handlers import start_datadog_logger
 
 __all__ = (
-    "DatadogFormatFactory",
+    "DatadogFormatter",
     "start_datadog_logger",
 )

--- a/datadoglog/formatters.py
+++ b/datadoglog/formatters.py
@@ -1,6 +1,6 @@
-import os
 import json
 import logging
+import os
 import traceback
 from datetime import datetime
 from datetime import timezone
@@ -10,10 +10,17 @@ class DatadogFormatFactory:
     """
     Formats our log record into a form that Datadog understands.
 
-    More information here: https://docs.datadoghq.com/logs/log_configuration/attributes_naming_convention/
+    More information here:
+    https://docs.datadoghq.com/logs/log_configuration/attributes_naming_convention/
     """
 
-    __slots__ = ("app_key", "service", "source", "env")
+    __slots__ = (
+        "app_key",
+        "env",
+        "host",
+        "service",
+        "source",
+    )
 
     def __init__(self, app_key: str, source: str, service: str, env: str) -> None:
         self.app_key = app_key
@@ -47,7 +54,7 @@ class DatadogFormatFactory:
             (exc_type, exc_value, exc_tb) = exc_info
             data["error.kind"] = str(exc_type)
             data["error.message"] = str(exc_value)
-            data["error.stack"] = "\n".join(traceback.format_tb(tb))
+            data["error.stack"] = "\n".join(traceback.format_tb(exc_tb))
 
         return f"{self.app_key} {json.dumps(data)}"
 

--- a/datadoglog/handlers.py
+++ b/datadoglog/handlers.py
@@ -13,7 +13,7 @@ class DatadogHandler(logging.handlers.SocketHandler):
     To understand the exact nature of what this Handler does, reference:
     https://github.com/python/cpython/blob/master/Lib/logging/handlers.py
     """
-    
+
     def __init__(self, *, print_debug: bool = False):
         """
         Initialize the parent SocketHandler with datadog's info. Hardcoding
@@ -29,7 +29,7 @@ class DatadogHandler(logging.handlers.SocketHandler):
 
     def makePickle(self, record: logging.LogRecord) -> bytes:
         """prepares record for writing over the wire"""
-        return f"{record.message}\n".encode("utf-8")
+        return f"{record.message}\n".encode()
 
     def send(self, s):
         """sends serialized s over the wire"""
@@ -54,11 +54,16 @@ class DatadogHandler(logging.handlers.SocketHandler):
         sock = socket.create_connection(self.address, timeout=timeout)
         conn = context.wrap_socket(sock, server_hostname=self.host)
         if self.print_debug:
-            print(f"datadoglog: makeSocket connected {conn} to {self.address} with {conn.version()}")
+            print(
+                f"datadoglog: makeSocket connected {conn} to {self.address} "
+                f"with {conn.version()}"
+            )
         return conn
 
 
-def start_datadog_logger(queue: Queue, *, print_debug: bool = False) -> Callable[[], None]:
+def start_datadog_logger(
+    queue: Queue, *, print_debug: bool = False
+) -> Callable[[], None]:
     """
     This starts the QueueListener in separate thread, which will consume and
     forward all the messages to Datadog, so the logging should never block the

--- a/datadoglog/handlers.py
+++ b/datadoglog/handlers.py
@@ -92,4 +92,11 @@ def start_datadog_logger(
 
     # start the listener and return our cancel/stop function to the caller
     listener.start()
-    return listener.stop
+
+    def closer():
+        # wait for anything in the queue to process
+        listener.stop()
+        # close the DatadogHandler
+        handler.close()
+
+    return closer

--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,14 @@
 import setuptools
 
-with open("README.md", "r") as fh:
-    long_description = fh.read()
+with open("README.md", encoding="utf-8") as f:
+    long_description = f.read()
 
 setuptools.setup(
     name="datadoglog",
-    version="0.1.0",
-    author="Jakub Labath",
-    author_email="jakubl@gadventures.com",
-    description="Logging to datadog log",
+    version="0.2.0",
+    author="Jakub Labath, Ammaar Esmailjee",
+    author_email="jakubl@gadventures.com, aesmailjee@gadventures.com",
+    description="Logging to datadog",
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/gadventures/datadoglog",


### PR DESCRIPTION
### NOTE: This contains breaking changes

### Changes

* `start_logger` renamed to `start_datadog_logger`
    + The returned function will first stop the internal QueueListener - which will attempt to push any remaining events to Datadog, followed by closing the DatadogHandler, which should closed the underlying Socket.

* `FormatFactory` renamed to `DatadogFormatter`
    + updates the logging attributes to be in line with Datadogs attributes/aliases documentation per their suggested naming conventions: [See here](https://docs.datadoghq.com/logs/log_configuration/attributes_naming_convention/)
        + `env` -> `dd.env`
        + `host` -> `dd.host`
        + `service` -> `dd.service`
        + `source` -> `dd.source`
        + `level` -> `status` 

* `DogHandler` renamed to `DatadogHandler` - no other internal changes, and does not need to be explicitly instantiated by a client, as the `start_datadog_logger` does this for us.

* Updated `README.md` to reflect the above changes
* Updated `LICENSE` date to 2023
* General formatting and ease of readability updates along with adding a basic `.pre-commit-config.yaml` file, and running it against the repo - did not result in significant changes, but found a few bugs through flake8/pylint.